### PR TITLE
Support Yarn 1.12 by using `--ignore-engines`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -19,7 +19,8 @@ command -v npm >/dev/null 2>&1 || {
   exit 1
 }
 
-# Ensure Yarn is installed
+# Ensure 
+is installed
 command -v yarn >/dev/null 2>&1 || {
   echo "This app requires Yarn package manager, but it was not found on your system."
   echo "Install it using the instructions at https://yarnpkg.com/en/"
@@ -44,7 +45,7 @@ echo "Installing Node.js dependencies (for assets)"
 echo "----------------------------------------------------------"
 
 cd assets/ && {
-  yarn install || { echo "Node dependencies could not be installed!"; exit 1; };
+  yarn install --ignore-engines || { echo "Node dependencies could not be installed!"; exit 1; };
   cd -;
 }
 

--- a/bin/setup
+++ b/bin/setup
@@ -19,8 +19,7 @@ command -v npm >/dev/null 2>&1 || {
   exit 1
 }
 
-# Ensure 
-is installed
+# Ensure yarn is installed
 command -v yarn >/dev/null 2>&1 || {
   echo "This app requires Yarn package manager, but it was not found on your system."
   echo "Install it using the instructions at https://yarnpkg.com/en/"


### PR DESCRIPTION
```
yarn install v1.12.3
[1/5] 🔍  Validating package.json...
error assets@1.0.0: The engine "node" is incompatible with this module. Expected version "7.5.0". Got "11.5.0"
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

```